### PR TITLE
Add CyberConnect to Decentralized Social Networks page

### DIFF
--- a/src/content/social-networks/index.md
+++ b/src/content/social-networks/index.md
@@ -95,6 +95,7 @@ In May 2022, [Instagram announced support for NFTs](https://about.instagram.com/
 - **[Mirror.xyz](https://mirror.xyz/)** - _Mirror is a decentralized, user-owned publishing platform built on Ethereum for users to crowdfund ideas, monetize content, and build high-value communities._
 - **[Lens Protocol](https://lens.xyz/)** - _Lens Protocol is a composable and decentralized social graph helping creators take ownership of their content wherever they go in the digital garden of the decentralized internet._
 - **[Farcaster](https://farcaster.xyz/)** - _Farcaster is a sufficiently decentralized social network. It is an open protocol that can support many clients, just like email._
+- **[CyberConnect](https://cyberconnect.me/)** - _CyberConnect is a Web3 social network that enables developers to create social applications with ERC-4337-powered smart accounts. It is a decentralized protocol that empowers users to own their digital identity, content, connections, and monetization._
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

I suggest adding CyberConnect to the list of decentralized social networks deployed on Ethereum. It is considered one of the leading social protocols in terms of user adoption and activity.

Adding CyberConnect will accurately represent the decentralized social network landscape on Ethereum, and provide users with a more comprehensive list of choices available to them.

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
